### PR TITLE
cleanup go project

### DIFF
--- a/go/bike.go
+++ b/go/bike.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+)
+
+// Bike is a type in Go that extends Vehicle
+type Bike struct {
+	Vehicle     // Embedding Vehicle to extend its fields and methods
+	gearCount   int
+	currentGear int
+}
+
+// Override move method for Bike
+func (b *Bike) move() {
+	fmt.Println("Bike is moving...")
+}
+
+// ringBell is a method specific to Bike
+func (b *Bike) ringBell() {
+	fmt.Println("Ring, ring!")
+}
+
+// gearShiftUp is a method to shift gears up in Bike
+func (b *Bike) gearShiftUp() {
+	b.currentGear++
+}
+
+// gearShiftUpWithCount is a method to shift gears up by a specified count in Bike
+func (b *Bike) gearShiftUpWithCount(gearCount int) {
+	b.currentGear += gearCount
+}

--- a/go/car.go
+++ b/go/car.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+)
+
+// Car is a type in Go that extends Vehicle and implements FuelDependent
+type Car struct {
+	Vehicle        // Embedding Vehicle to extend its fields and methods
+	doorCount      int
+	passengerCount int
+	fuelLevel      float32
+}
+
+// Implementing refuel method for Car (required by FuelDependent interface)
+func (c *Car) refuel(liter float32) {
+	// Implement refuel logic here
+	c.fuelLevel += liter
+	fmt.Printf("Refueled. Current fuel level: %f liters\n", c.fuelLevel)
+}
+
+// Override move method for Car
+func (c *Car) move() {
+	fmt.Println("Car is moving...")
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,5 +1,3 @@
-module "go"
+module example
 
 go 1.21
-
-require golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1

--- a/go/interfaces.go
+++ b/go/interfaces.go
@@ -1,0 +1,5 @@
+package main
+
+type FuelDependent interface {
+	refuel(liter float32)
+}

--- a/go/main.go
+++ b/go/main.go
@@ -1,123 +1,9 @@
-/*
-*****************************************************************************
-Welcome to GDB Online.
-GDB online is an online compiler and debugger tool for C, C++, Python, Java, PHP, Ruby, Perl,
-C#, OCaml, VB, Swift, Pascal, Fortran, Haskell, Objective-C, Assembly, HTML, CSS, JS, SQLite, Prolog.
-Code, Compile, Run and Debug online from anywhere in world.
-
-******************************************************************************
-*/
 package main
 
 import (
 	"fmt"
 	"time"
 )
-
-type Vehicle struct {
-	topSpeed          float32
-	weight            float32
-	manufacturingDate time.Time
-}
-
-// Move is an abstract method in Go
-func (v *Vehicle) move() {
-	fmt.Println("Moving...")
-}
-
-type FuelDependent interface {
-	refuel(liter float32)
-}
-
-// Train is a type in Go that extends Vehicle and implements FuelDependent
-type Train struct {
-	Vehicle    // Embedding Vehicle to extend its fields and methods
-	wagonCount int
-}
-
-// Implementing move method for Train
-func (t *Train) move() {
-	fmt.Println("Train is moving...")
-}
-
-// PassengerTrain is a type in Go that extends Train
-type PassengerTrain struct {
-	Train          // Embedding Train to extend its fields and methods
-	passengerCount int
-}
-
-// Implementing refuel method for PassengerTrain (required by FuelDependent interface)
-func (pt *PassengerTrain) refuel(liter float32) {
-	// Implement refuel logic here
-}
-
-// Override move method for PassengerTrain
-func (pt *PassengerTrain) move() {
-	fmt.Println("Passenger train is moving...")
-}
-
-// FreightTrain is a type in Go that extends Train
-type FreightTrain struct {
-	Train         // Embedding Train to extend its fields and methods
-	carryCapacity float32
-}
-
-// Implementing refuel method for FreightTrain (required by FuelDependent interface)
-func (ft *FreightTrain) refuel(liter float32) {
-	// Implement refuel logic here
-}
-
-// Override move method for FreightTrain
-func (ft *FreightTrain) move() {
-	fmt.Println("Freight train is moving...")
-}
-
-// Car is a type in Go that extends Vehicle and implements FuelDependent
-type Car struct {
-	Vehicle        // Embedding Vehicle to extend its fields and methods
-	doorCount      int
-	passengerCount int
-	fuelLevel      float32
-}
-
-// Implementing refuel method for Car (required by FuelDependent interface)
-func (c *Car) refuel(liter float32) {
-	// Implement refuel logic here
-	c.fuelLevel += liter
-	fmt.Printf("Refueled. Current fuel level: %f liters\n", c.fuelLevel)
-}
-
-// Override move method for Car
-func (c *Car) move() {
-	fmt.Println("Car is moving...")
-}
-
-// Bike is a type in Go that extends Vehicle
-type Bike struct {
-	Vehicle     // Embedding Vehicle to extend its fields and methods
-	gearCount   int
-	currentGear int
-}
-
-// Override move method for Bike
-func (b *Bike) move() {
-	fmt.Println("Bike is moving...")
-}
-
-// ringBell is a method specific to Bike
-func (b *Bike) ringBell() {
-	fmt.Println("Ring, ring!")
-}
-
-// gearShiftUp is a method to shift gears up in Bike
-func (b *Bike) gearShiftUp() {
-	b.currentGear++
-}
-
-// gearShiftUpWithCount is a method to shift gears up by a specified count in Bike
-func (b *Bike) gearShiftUpWithCount(gearCount int) {
-	b.currentGear += gearCount
-}
 
 func main() {
 	var vehicle = Vehicle{
@@ -136,6 +22,9 @@ func main() {
 		passengerCount: 4,
 		fuelLevel:      0,
 	}
+
+	jam := TrafficJam[Car]{}
+	jam.addVehicle(car)
 
 	fmt.Printf("Top Speed: %f\n", vehicle.topSpeed)
 }

--- a/go/trafficjam.go
+++ b/go/trafficjam.go
@@ -1,0 +1,13 @@
+package main
+
+type TrafficJam[T any] struct {
+	queue []T
+}
+
+func (t *TrafficJam[T]) addVehicle(vehicle T) {
+	t.queue = append(t.queue, vehicle)
+}
+
+func (t *TrafficJam[T]) jamLength() int {
+	return len(t.queue)
+}

--- a/go/train.go
+++ b/go/train.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+)
+
+// Train is a type in Go that extends Vehicle and implements FuelDependent
+type Train struct {
+	Vehicle    // Embedding Vehicle to extend its fields and methods
+	wagonCount int
+}
+
+// Implementing move method for Train
+func (t *Train) move() {
+	fmt.Println("Train is moving...")
+}
+
+// PassengerTrain is a type in Go that extends Train
+type PassengerTrain struct {
+	Train          // Embedding Train to extend its fields and methods
+	passengerCount int
+}
+
+// Implementing refuel method for PassengerTrain (required by FuelDependent interface)
+func (pt *PassengerTrain) refuel(liter float32) {
+	// Implement refuel logic here
+}
+
+// Override move method for PassengerTrain
+func (pt *PassengerTrain) move() {
+	fmt.Println("Passenger train is moving...")
+}
+
+// FreightTrain is a type in Go that extends Train
+type FreightTrain struct {
+	Train         // Embedding Train to extend its fields and methods
+	carryCapacity float32
+}
+
+// Implementing refuel method for FreightTrain (required by FuelDependent interface)
+func (ft *FreightTrain) refuel(liter float32) {
+	// Implement refuel logic here
+}
+
+// Override move method for FreightTrain
+func (ft *FreightTrain) move() {
+	fmt.Println("Freight train is moving...")
+}

--- a/go/vehicle.go
+++ b/go/vehicle.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+type Vehicle struct {
+	topSpeed          float32
+	weight            float32
+	manufacturingDate time.Time
+}
+
+// Move is an abstract method in Go
+func (v *Vehicle) move() {
+	fmt.Println("Moving...")
+}


### PR DESCRIPTION
Ich habe mal die go Datei aufgeteilt und einzelne Dateien draus gezaubert. VS code kommt damit nur zurecht, wenn man den go Ordner direkt als workspace-root öffnet. 

Mit `go run ./go` kann man es aber per Hand ausführen und es klappt auch ohne Fehler.
